### PR TITLE
Fix page_for_post_types_keys default value

### DIFF
--- a/admin/class-page-for-post-types-admin.php
+++ b/admin/class-page-for-post-types-admin.php
@@ -61,7 +61,8 @@ class Page_For_Post_Types_Admin {
 		$shared     = new Page_For_Post_Types_Shared( $this->plugin_name, $this->version );
 		$post_types = $shared->get_page_for_post_type_objects();
 
-		$page_for_post_types_keys = get_option( 'page_for_post_types_keys' );
+		$page_for_post_types_keys = get_option('page_for_post_types_keys', []); // Set default as empty array
+
 
 		foreach ( $post_types as $post_type ) {
 			$option_name        = $shared->option_name( $post_type->name );

--- a/public/class-page-for-post-types-public.php
+++ b/public/class-page-for-post-types-public.php
@@ -87,6 +87,8 @@ class Page_For_Post_Types_Public {
 				'slug'       => $shared->get_rewrite_slug( $page_for ),
 				'with_front' => false,
 			];
+
+      $args['has_archive'] = $shared->get_rewrite_slug( $page_for );
 			//TODO: DO we need this setting?
 			$args['post_type_page_id'] = $page_for;
 


### PR DESCRIPTION
This pull request fixes the default value of the `page_for_post_types_keys` option to be an empty array. Additionally, it sets the `has_archive` argument to the value of the `rewrite_slug` for the post type.