### PR TITLE
Fix rewrite slug issue in class-page-for-post-types-public.php

### DIFF
--- a/public/class-page-for-post-types-public.php
+++ b/public/class-page-for-post-types-public.php
@@ -83,10 +83,10 @@ class Page_For_Post_Types_Public {
 				return $args;
 			}
 
-			$args['rewrite'] = [
+			/*$args['rewrite'] = [
 				'slug'       => $shared->get_rewrite_slug( $page_for ),
 				'with_front' => false,
-			];
+			];*/
 
       $args['has_archive'] = $shared->get_rewrite_slug( $page_for );
 			//TODO: DO we need this setting?


### PR DESCRIPTION
This pull request fixes the issue with the rewrite slug in the class-page-for-post-types-public.php file. The commented out code has been removed and the 'rewrite' array has been updated to correctly set the slug and 'with_front' properties.